### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Pods/JSONCodable/README.md
+++ b/Pods/JSONCodable/README.md
@@ -17,7 +17,7 @@
          alt="License">
 </p>
 
-#JSONCodable
+# JSONCodable
 Hassle-free JSON encoding and decoding in Swift
 
 ### Installation
@@ -117,7 +117,7 @@ Result:
 )]
 ```
 
-##Using JSONDecodable
+## Using JSONDecodable
 
 Simply add conformance to `JSONDecodable` (or to `JSONCodable`):
 ```swift

--- a/Pods/UIColor_Hex_Swift/README.md
+++ b/Pods/UIColor_Hex_Swift/README.md
@@ -16,9 +16,9 @@ Convenience method for creating autoreleased color using RGBA hex string.
 
     var hexString = UIColor.redColor().hexString(false) // "#FF0000"
 
-##Installation
+## Installation
 
-###[CocoaPods](http://cocoapods.org)
+### [CocoaPods](http://cocoapods.org)
 
 Simply add the following lines to your `Podfile`:
 ```ruby
@@ -35,7 +35,7 @@ import UIColor_Hex_Swift
 
 *(CocoaPods v0.36 or later required. See [this blog post](http://blog.cocoapods.org/Pod-Authors-Guide-to-CocoaPods-Frameworks/) for details.)*
 
-###[Carthage](http://github.com/Carthage/Carthage)
+### [Carthage](http://github.com/Carthage/Carthage)
 
 Simply add the following line to your `Cartfile`:
 

--- a/Pods/UIImageViewModeScaleAspect/README.md
+++ b/Pods/UIImageViewModeScaleAspect/README.md
@@ -24,7 +24,7 @@ pod 'UIImageViewModeScaleAspect'
 
 <p>Import the .h file :</p>
 ``` objective-c
-#import "UIImageViewModeScaleAspect.h"
+# import "UIImageViewModeScaleAspect.h"
 ```
 
 <p>Init the UIImageViewModeScaleAspect. Important ! Do not forget to init the contentMode :</p>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
